### PR TITLE
Port design changes from onnxruntime-genai PR #2078

### DIFF
--- a/modelbuilder/builder.py
+++ b/modelbuilder/builder.py
@@ -209,6 +209,7 @@ def create_model(model_name, input_path, output_dir, precision, execution_provid
         from .builders.gemma import Gemma3Model
 
         onnx_model = Gemma3Model(config, io_dtype, onnx_dtype, execution_provider, cache_dir, extra_options)
+        onnx_model.model_type = "gemma3"
     elif config.architectures[0] == "Gemma4ForCausalLM":
         print(
             "WARNING: This model loses accuracy with float16 precision. It is recommended to set `--precision bf16` or `--precision int4 --extra_options use_cuda_bf16=true` by default."

--- a/modelbuilder/builders/base.py
+++ b/modelbuilder/builders/base.py
@@ -529,11 +529,6 @@ class Model(LocalFunctionsMixin):
             # if rope_scaling provides one.
             if "rope_theta" in config.rope_scaling:
                 self.rope_attrs["theta"] = config.rope_scaling["rope_theta"]
-            # Some models (e.g. Qwen3-VL) store rope_theta inside rope_scaling
-            # instead of as a top-level config attribute. Override the default theta
-            # if rope_scaling provides one.
-            if "rope_theta" in config.rope_scaling:
-                self.rope_attrs["theta"] = config.rope_scaling["rope_theta"]
 
     def is_gqa_supported(self) -> bool:
         valid_gqa_configurations = {
@@ -2918,6 +2913,10 @@ class Model(LocalFunctionsMixin):
         self.make_attention_output_proj(layer_id, attention, root_input, **kwargs)
 
     def make_attention_input_proj(self, layer_id, attention, root_input, **kwargs):
+        self.attention_attrs["q_path"] = ""
+        self.attention_attrs["k_path"] = ""
+        self.attention_attrs["v_path"] = ""
+
         # Unpack attention weights if needed
         self.make_attention_unpacked(layer_id, attention, root_input, **kwargs)
 


### PR DESCRIPTION
- Set model_type='gemma3' for Gemma3ForConditionalGeneration in builder.py
- Reset q_path/k_path/v_path at start of make_attention_input_proj to prevent stale values from packed-attention path leaking into the next layer
- Remove duplicate rope_theta override block in mrope section

Closes #358