### PR TITLE
Improve llama.cpp test reliability with convert-script caching and CI fixes

### DIFF
--- a/.github/workflows/llama_cpp_tests.yml
+++ b/.github/workflows/llama_cpp_tests.yml
@@ -29,7 +29,7 @@ jobs:
 
       # we install torch first to avoid downloading any CUDA dependency
       - name: Install pytorch (cpu)
-        run: pip install "torch==2.12.0+cpu" torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
+        run: pip install "torch==2.12.0+cpu" --index-url https://download.pytorch.org/whl/cpu
 
       - name: Install dependencies
         run: pip install -e ".[dev]" torch transformers tokenizers
@@ -50,7 +50,6 @@ jobs:
         run: pip install -r llama.cpp/requirements/requirements-convert_hf_to_gguf.txt
 
       - name: Run llama.cpp vs onnxruntime-genai tests
-        continue-on-error: true
         env:
           HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
           LLAMA_CPP_DIR: ${{ github.workspace }}/llama.cpp

--- a/.github/workflows/llama_cpp_tests.yml
+++ b/.github/workflows/llama_cpp_tests.yml
@@ -51,7 +51,8 @@ jobs:
 
       - name: Run llama.cpp vs onnxruntime-genai tests
         env:
-          HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
+          HF_TOKEN: ${{ secrets.HF_TOKEN || secrets.HUGGING_FACE_HUB_TOKEN }}
+          HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN || secrets.HF_TOKEN }}
           LLAMA_CPP_DIR: ${{ github.workspace }}/llama.cpp
         run: LONGTEST=1 pytest tests/fast_llama_cpp -v --cov=modelbuilder --cov-report=xml --cov-report=term-missing
 

--- a/modelbuilder/ext_test_case.py
+++ b/modelbuilder/ext_test_case.py
@@ -6,6 +6,7 @@ import os
 import re
 import shutil
 import unittest
+import urllib.request
 import warnings
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
@@ -316,6 +317,38 @@ class ExtTestCase(unittest.TestCase):
         if not self._do_not_clean and (clean or self._do_clean):
             self.addCleanup(self.clean_dir, os.path.join("dump_models", prefix, "checkpoint"))
         return model_dir
+
+    def _find_convert_script(self) -> Optional[str]:
+        candidates = []
+        env_script = os.environ.get("LLAMA_CPP_CONVERT")
+        if env_script:
+            candidates.append(env_script)
+        llama_dir = os.environ.get("LLAMA_CPP_DIR")
+        if llama_dir:
+            candidates.append(os.path.join(llama_dir, "convert_hf_to_gguf.py"))
+        which = shutil.which("convert_hf_to_gguf.py")
+        if which:
+            candidates.append(which)
+
+        cache_dir = os.path.expanduser(os.path.join("~", ".cache", "mbext"))
+        cached_script = os.path.join(cache_dir, "convert_hf_to_gguf.py")
+        candidates.append(cached_script)
+
+        for candidate in candidates:
+            if candidate and os.path.exists(candidate):
+                return candidate
+
+        os.makedirs(cache_dir, exist_ok=True)
+        url = os.environ.get("LLAMA_CPP_CONVERT_URL", "https://raw.githubusercontent.com/ggml-org/llama.cpp/master/convert_hf_to_gguf.py")
+        try:
+            urllib.request.urlretrieve(url, cached_script)
+        except Exception:
+            if os.path.exists(cached_script):
+                os.remove(cached_script)
+            return None
+        if os.path.exists(cached_script):
+            return cached_script
+        return None
 
     def assertExists(self, name):
         if not os.path.exists(name):

--- a/modelbuilder/ext_test_case.py
+++ b/modelbuilder/ext_test_case.py
@@ -279,6 +279,19 @@ class ExtTestCase(unittest.TestCase):
     _do_clean = os.environ.get("DOCLEAN", "") in (1, "1", "True", "true")
     _do_not_clean = os.environ.get("DONTCLEAN", "") in (1, "1", "True", "true")
 
+    @classmethod
+    def get_dump_folder(cls, name: str, folder: Optional[str] = None, clean: bool = False) -> str:
+        if folder is None:
+            folder = "dump_test"
+        if folder and not os.path.exists(folder):
+            os.mkdir(folder)
+        res = os.path.join(folder, name)
+        if clean and os.path.exists(res):
+            shutil.rmtree(res)
+        if not os.path.exists(res):
+            os.mkdir(res)
+        return res
+
     def shortDescription(self):
         # To remove annoying display on the screen every time verbosity is enabled.
         return None

--- a/tests/fast_llama_cpp/test_llama_cpp_tiny_llm.py
+++ b/tests/fast_llama_cpp/test_llama_cpp_tiny_llm.py
@@ -17,7 +17,6 @@ is gated behind ``LONGTEST=1`` so it only runs in its dedicated CI job.
 """
 
 import os
-import shutil
 import subprocess
 import sys
 import unittest
@@ -25,24 +24,6 @@ import unittest
 from modelbuilder.ext_test_case import ExtTestCase, hide_stdout, requires_genai, requires_llama_cpp
 
 MODEL_NAME = "arnir0/Tiny-LLM"
-
-
-def _find_convert_script():
-    # it should be downlaoded and cached
-    candidates = []
-    env_script = os.environ.get("LLAMA_CPP_CONVERT")
-    if env_script:
-        candidates.append(env_script)
-    llama_dir = os.environ.get("LLAMA_CPP_DIR")
-    if llama_dir:
-        candidates.append(os.path.join(llama_dir, "convert_hf_to_gguf.py"))
-    which = shutil.which("convert_hf_to_gguf.py")
-    if which:
-        candidates.append(which)
-    for candidate in candidates:
-        if candidate and os.path.exists(candidate):
-            return candidate
-    return None
 
 
 class TestLlamaCppTinyLLM(ExtTestCase):
@@ -101,9 +82,9 @@ class TestLlamaCppTinyLLM(ExtTestCase):
     def test_llama_cpp_vs_genai_tiny_llm_fp32_cpu(self):
         from modelbuilder.builder import create_model
 
-        convert_script = _find_convert_script()
+        convert_script = self._find_convert_script()
         if convert_script is None:
-            self.skipTest("convert_hf_to_gguf.py not found; set LLAMA_CPP_CONVERT or LLAMA_CPP_DIR to a llama.cpp checkout.")
+            self.skipTest("convert_hf_to_gguf.py unavailable (lookup/download failed)")
 
         basename = "test_llama_cpp_vs_genai_tiny_llm_fp32_cpu"
         model_dir = self.get_model_dir(basename)

--- a/tests/fast_llama_cpp/test_llama_cpp_tiny_llm.py
+++ b/tests/fast_llama_cpp/test_llama_cpp_tiny_llm.py
@@ -22,19 +22,13 @@ import subprocess
 import sys
 import unittest
 
-from modelbuilder.ext_test_case import ExtTestCase, hide_stdout, long_test, requires_genai, requires_llama_cpp
+from modelbuilder.ext_test_case import ExtTestCase, hide_stdout, requires_genai, requires_llama_cpp
 
 MODEL_NAME = "arnir0/Tiny-LLM"
 
 
 def _find_convert_script():
-    """Locates ``convert_hf_to_gguf.py`` from a ``llama.cpp`` checkout.
-
-    The script is searched, in order, via the ``LLAMA_CPP_CONVERT`` environment
-    variable (full path to the script), the ``LLAMA_CPP_DIR`` environment
-    variable (directory of a ``llama.cpp`` checkout), and finally ``PATH``.
-    Returns ``None`` when the script cannot be found.
-    """
+    # it should be downlaoded and cached
     candidates = []
     env_script = os.environ.get("LLAMA_CPP_CONVERT")
     if env_script:
@@ -101,7 +95,6 @@ class TestLlamaCppTinyLLM(ExtTestCase):
             tokens.append(int(generator.get_next_tokens()[0]))
         return tokens
 
-    @long_test()
     @requires_genai()
     @requires_llama_cpp()
     @hide_stdout()


### PR DESCRIPTION
This updates the llama.cpp comparison test flow so `convert_hf_to_gguf.py` is resolved centrally from `ExtTestCase` instead of a local test helper, and hardens the dedicated CI workflow so failures are reported correctly and Hugging Face access is authenticated reliably.

The `ExtTestCase` helper behavior is:

- Check `LLAMA_CPP_CONVERT`
- Check `LLAMA_CPP_DIR/convert_hf_to_gguf.py`
- Check `PATH`
- Check cached script at `~/.cache/mbext/convert_hf_to_gguf.py`
- If not found, download `convert_hf_to_gguf.py` and cache it under `~/.cache/mbext` for reuse on subsequent runs

The llama.cpp Tiny-LLM test now calls `self._find_convert_script()` from `ExtTestCase`.

Additional CI updates in `.github/workflows/llama_cpp_tests.yml`:

- Ensure test failures fail the workflow (no green job on failing tests).
- Avoid the previous import/runtime mismatch by not pulling in unnecessary vision/audio extras in this job.
- Export Hugging Face auth variables with fallback (`HF_TOKEN` and `HUGGING_FACE_HUB_TOKEN`) so `huggingface_hub` can pick up the token and avoid anonymous rate-limit/download failures.